### PR TITLE
Fix `a.b` being parsed as infix expression with '.' being the op

### DIFF
--- a/grammar/exp.js
+++ b/grammar/exp.js
@@ -44,7 +44,7 @@ module.exports = {
 
   exp_record_access: $ =>
     prec(1, seq(
-      choice($.hole, $.record_literal, $.exp_parens),
+      choice($.hole, $.record_literal, $.exp_parens, $._qvarid),
       repeat1(seq($._immediate_dot, field('field', $._immediate_variable)))
     )),
 

--- a/grammar/rows_and_records.js
+++ b/grammar/rows_and_records.js
@@ -112,6 +112,7 @@ module.exports = {
       $.hole,
       $._qvarid,
       $.record_literal,
+      $.exp_record_access,
       $.exp_parens,
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -117,8 +117,9 @@
 
  (row_field (field_name) @variable.other.member)
  (record_field (field_name) @variable.other.member)
- (record_accessor (variable) @variable.other.member)
- (exp_record_access (variable) @variable.other.member)
+ (record_field (field_pun) @field)
+ (record_accessor field: (variable) @variable.other.member)
+ (exp_record_access field: (variable) @variable.other.member)
 
  (signature name: (variable) @type)
  (function name: (variable) @function)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1433,6 +1433,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "exp_record_access"
+        },
+        {
+          "type": "SYMBOL",
           "name": "exp_parens"
         }
       ]
@@ -2239,6 +2243,10 @@
               {
                 "type": "SYMBOL",
                 "name": "exp_parens"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_qvarid"
               }
             ]
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2698,7 +2698,15 @@
           "named": true
         },
         {
+          "type": "qualified_variable",
+          "named": true
+        },
+        {
           "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "variable",
           "named": true
         }
       ]


### PR DESCRIPTION
Closes #3 