### PR TITLE
Fix Applicative Do notation

### DIFF
--- a/grammar/decl.js
+++ b/grammar/decl.js
@@ -19,7 +19,7 @@ module.exports = {
       seq('=', field('rhs', $._exp)),
       $._fun_guards,
     ),
-    optional(seq($.where, optional($.decls))),
+    optional(seq($.where, $.declarations)),
   ),
 
   _fun_patterns: $ => repeat1($._apat),
@@ -72,7 +72,7 @@ module.exports = {
     $._decl_fun,
   ),
 
-  decls: $ => layouted($, $._decl),
+  declarations: $ => layouted($, $._decl),
 
   // ------------------------------------------------------------------------
   // Foreign

--- a/grammar/exp.js
+++ b/grammar/exp.js
@@ -1,19 +1,53 @@
-const { parens, brackets, sep1, layouted, qualified, ticked } = require('./util.js')
+const { brackets, layouted, layouted_without_end, parens, qualified, sep, sep1, ticked } = require('./util.js')
+
+/* ----- Composite expressions shared between do/ado and regular notation -----
+
+The point of these is that we want them exactly the same for regular
+notation and `do`/`ado` notation, except the let-in expressions.
+These are not allowed in `do`/`ado` blocks, and are tricky to parse in
+`ado` blocks specifically due to ambiguity stemming from `ado` block
+terminator being `in`:
+
+f = ado
+  let a = []
+  in a
+
+But `do` and `ado` blocks have mutual dependency with all other expressions
+so they would have to be defined in the same module.
+*/
+
+const __lexp = ($, ...rule) =>
+  choice(
+    $.exp_if,
+    $.exp_case,
+    $.exp_negation,
+    $.exp_lambda,
+    $._fexp,
+    ...rule
+  )
 
 module.exports = {
-  // ------------------------------------------------------------------------
-  // expression
-  // ------------------------------------------------------------------------
+
+  // ----- Identifiers and modifiers ------------------------------------------
+
+  exp_name: $ => choice(
+    $._qvar,
+    $._qcon,
+  ),
+
+  exp_ticked: $ => ticked($._exp_infix),
+
+  exp_negation: $ => seq('-', $._aexp),
 
   exp_parens: $ => parens($._exp),
 
+  exp_type_application: $ => seq('@', $._atype),
+
+  // ----- Arrays -------------------------------------------------------------
+
   exp_array: $ => brackets(sep($.comma, $._exp)),
 
-  bind_pattern: $ => seq(
-    $._typed_pat,
-    $._larrow,
-    $._exp,
-  ),
+  // ----- Operator sections --------------------------------------------------
 
   exp_section_left: $ => parens(
     $.wildcard,
@@ -27,14 +61,7 @@ module.exports = {
     $.wildcard
   ),
 
-  exp_type_application: $ => seq('@', $._atype),
-
-  exp_lambda: $ => seq(
-    '\\',
-    repeat1($._apat),
-    $._arrow,
-    $._exp,
-  ),
+  // ----- Records ------------------------------------------------------------
 
   _record_access_field: $ =>
     choice(
@@ -55,15 +82,7 @@ module.exports = {
       repeat1(seq($._immediate_dot, field('field', $._record_access_field)))
     )),
 
-  exp_in: $ => seq('in', $._exp),
-
-  let: $ => seq('let', optional($.decls)),
-
-  _let_decls: $ => layouted_without_end($, $._decl),
-
-  exp_let: $ => seq('let', optional(alias($._let_decls, $.decls))),
-
-  exp_let_in: $ => seq($.exp_let, $.exp_in),
+  // ----- If-then-else -------------------------------------------------------
 
   exp_if: $ => seq(
     'if',
@@ -74,38 +93,45 @@ module.exports = {
     field('else', choice($.wildcard, $._exp)),
   ),
 
-  pattern_guard: $ => seq(
-    $._pat,
-    $._larrow,
-    $._exp_infix,
-  ),
+  // ----- Case-of ------------------------------------------------------------
 
-  guard: $ => choice(
-    $.pattern_guard,
-    $.let,
-    $._exp_infix,
-  ),
+  pattern_guard: $ =>
+    seq(
+      $._pat,
+      $._larrow,
+      $._exp_infix,
+    ),
+
+  guard: $ =>
+    choice(
+      $.pattern_guard,
+      $._exp_infix,
+    ),
 
   guards: $ => seq('|', sep1($.comma, $.guard)),
 
   gdpat: $ => seq($.guards, $._arrow, $._exp),
 
-  _alt_variants: $ => choice(
-    seq($._arrow, field('exp', $._exp)),
-    repeat1($.gdpat),
-  ),
+  _alt_variants: $ =>
+    choice(
+      seq($._arrow, field('exp', $._exp)),
+      repeat1($.gdpat),
+    ),
 
-  alt: $ => seq(
-    sep1($.comma, field('pat', $._pat)),
-    $._alt_variants,
-    optional(seq($.where, optional($.decls)))
-  ),
+  alt: $ =>
+    seq(
+      sep1($.comma, field('pat', $._pat)),
+      $._alt_variants,
+      optional(seq($.where, $.declarations))
+    ),
 
   alts: $ => layouted($, $.alt),
 
-  _exp_case_slots: $ => sep1($.comma,
-    field('condition', choice($.wildcard, $._exp))
-  ),
+  _exp_case_slots: $ =>
+    sep1(
+      $.comma,
+      field('condition', choice($.wildcard, $._exp))
+    ),
 
   exp_case: $ => seq(
     'case',
@@ -114,24 +140,82 @@ module.exports = {
     $.alts
   ),
 
-  stmt: $ => choice(
+  // ----- Let-in -------------------------------------------------------------
+
+  _let_decls: $ => layouted_without_end($, $._decl),
+
+  exp_let_in: $ =>
+    seq(
+      'let',
+      alias($._let_decls, $.declarations),
+      'in',
+      $._exp
+    ),
+
+  // ----- Lambdas ------------------------------------------------------------
+
+  exp_lambda: $ => seq(
+    '\\',
+    repeat1($._apat),
+    $._arrow,
     $._exp,
-    $.bind_pattern,
-    $.let,
   ),
 
-  _do_keyword: _ => choice('ado', 'do'),
+  // ----- do and ado notation ------------------------------------------------
 
-  do_module: $ => qualified($, $._do_keyword),
+  _statement_lexp: $ => __lexp($),
 
-  exp_do: $ => seq(choice($.do_module, $._do_keyword), layouted($, $.stmt)),
+  __statement_exp_infix: $ =>
+    seq(
+      $._statement_exp_infix,
+      choice($._q_op, $.exp_ticked),
+      $._lexp
+    ),
 
-  exp_negation: $ => seq('-', $._aexp),
+  _statement_exp_infix: $ =>
+    choice(
+      alias($.__statement_exp_infix, $.exp_infix),
+      $._statement_lexp
+    ),
 
-  exp_name: $ => choice(
-    $._qvar,
-    $._qcon,
-  ),
+  _statement_exp: $ =>
+    prec.right(seq($._statement_exp_infix, optional($._type_annotation))),
+
+  bind_pattern: $ =>
+    seq(
+      $._typed_pat,
+      $._larrow,
+      $._exp,
+    ),
+
+  let: $ => seq('let', $.declarations),
+
+  statement: $ =>
+    choice(
+      $._statement_exp,
+      $.bind_pattern,
+      $.let,
+    ),
+
+  _do_kw: _ => 'do',
+  _do: $ => choice('do', qualified($, $._do_kw)),
+  exp_do: $ => seq($._do, layouted($, $.statement)),
+
+  _ado_kw: _ => 'ado',
+  _ado: $ => choice('ado', qualified($, $._ado_kw)),
+  _ado_in: $ => seq('in', field('in', $._exp)),
+
+  exp_ado: $ =>
+    seq(
+      $._ado,
+      layouted_without_end($, $.statement),
+      $._ado_in, // TODO try wrap it in `layouted_without_end` ?
+      $._layout_end,
+    ),
+
+  _do_or_ado_block: $ => choice($.exp_do, $.exp_ado),
+
+  // ----- Composite expressions ----------------------------------------------
 
   /**
    * The Report lists for `aexp` only expressions that don't have any unbracketed whitespace, except for record
@@ -173,7 +257,7 @@ module.exports = {
   _aexp: $ => choice(
     $._aexp_projection,
     $.exp_type_application,
-    $.exp_do,
+    $._do_or_ado_block
   ),
 
   /**
@@ -183,14 +267,15 @@ module.exports = {
    * in the reference, it can only occur after an infix operator; if it is in `aexp`, it causes lots of problems.
    * Furthermore, the strange way the recursion is done here is to avoid local conflicts.
    */
-  _exp_apply: $ => choice(
-    $._aexp,
-    seq($._aexp, $._exp_apply),
-    seq($._aexp, $.exp_lambda),
-    seq($._aexp, $.exp_let_in),
-    seq($._aexp, $.exp_if),
-    seq($._aexp, $.exp_case),
-  ),
+  _exp_apply: $ =>
+    choice(
+      $._aexp,
+      seq($._aexp, $._exp_apply),
+      seq($._aexp, $.exp_lambda),
+      seq($._aexp, $.exp_if),
+      seq($._aexp, $.exp_case),
+      seq($._aexp, $.exp_let_in),
+    ),
 
   /**
    * The point of this `choice` is to get a node for function application only if there is more than one expression
@@ -201,16 +286,7 @@ module.exports = {
     alias($._exp_apply, $.exp_apply),
   ),
 
-  _lexp: $ => choice(
-    $.exp_let_in,
-    $.exp_if,
-    $.exp_case,
-    $.exp_negation,
-    $._fexp,
-    $.exp_lambda,
-  ),
-
-  exp_ticked: $ => ticked($._exp_infix),
+  _lexp: $ => __lexp($, $.exp_let_in),
 
   /**
    * This is left-associative, although in reality this would depend on the fixity declaration for the operator.
@@ -219,10 +295,7 @@ module.exports = {
    */
   exp_infix: $ => seq(
     $._exp_infix,
-    choice(
-      $._q_op,
-      $.exp_ticked
-      ),
+    choice($._q_op, $.exp_ticked),
     $._lexp
   ),
 

--- a/grammar/util.js
+++ b/grammar/util.js
@@ -65,17 +65,18 @@ where = ($, rule) => seq(
 varid_pattern = /[\p{Ll}_][\p{L}0-9_']*/u
 
 module.exports = {
-  parens,
   braces,
   brackets,
-  ticked,
-  quote,
+  layouted,
+  layouted_without_end,
+  parens,
   qualified,
+  quote,
   sep,
   sep1,
   sep2,
   terminated,
-  layouted,
-  where,
+  ticked,
   varid_pattern,
+  where,
 }

--- a/test/corpus/exp_do_ado.txt
+++ b/test/corpus/exp_do_ado.txt
@@ -11,7 +11,7 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (exp_apply
           (exp_name
             (variable))
@@ -34,13 +34,13 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (bind_pattern
           (pat_name
             (variable))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (bind_pattern
           (pat_apply
             (pat_name
@@ -49,7 +49,7 @@ f = do
               (variable)))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (bind_pattern
           (pat_apply
             (pat_name
@@ -60,7 +60,7 @@ f = do
               (variable)))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (exp_apply
           (exp_name
             (variable))
@@ -83,16 +83,16 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
               name: (variable)
               rhs: (exp_name
                 (variable))))))
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
               pattern: (pat_apply
                 (pat_name
@@ -101,9 +101,9 @@ f = do
                   (variable)))
               rhs: (exp_name
                 (variable))))))
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
               pattern: (pat_apply
                 (pat_name
@@ -114,7 +114,7 @@ f = do
                   (variable)))
               rhs: (exp_name
                 (variable))))))
-      (stmt
+      (statement
         (exp_apply
           (exp_name
             (variable))
@@ -135,9 +135,9 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (exp_do
-          (stmt
+          (statement
             (exp_apply
               (exp_name
                 (variable))
@@ -149,44 +149,39 @@ Ado-notation
 ================================================================================
 
 f = ado
-  in 1
+  in []
 
 --------------------------------------------------------------------------------
 
 (purescript
   (function
     name: (variable)
-    rhs: (exp_do
-      (stmt
-        (exp_apply
-          (exp_name
-            (variable))
-          (exp_literal
-            (integer)))))))
+    rhs: (exp_ado
+      in: (exp_array))))
 
 ================================================================================
 Ado-notation, bind-binders
 ================================================================================
 
-f = do
+f = ado
   a <- b
   C d <- f
   G h i <- j
-  in 1
+  in []
 
 --------------------------------------------------------------------------------
 
 (purescript
   (function
     name: (variable)
-    rhs: (exp_do
-      (stmt
+    rhs: (exp_ado
+      (statement
         (bind_pattern
           (pat_name
             (variable))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (bind_pattern
           (pat_apply
             (pat_name
@@ -195,7 +190,7 @@ f = do
               (variable)))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (bind_pattern
           (pat_apply
             (pat_name
@@ -206,18 +201,13 @@ f = do
               (variable)))
           (exp_name
             (variable))))
-      (stmt
-        (exp_apply
-          (exp_name
-            (variable))
-          (exp_literal
-            (integer)))))))
+      in: (exp_array))))
 
 ================================================================================
 Ado-notation, let-binders
 ================================================================================
 
-f = do
+f = ado
   let a = b
   let C d = f
   let G h i = j
@@ -227,46 +217,44 @@ f = do
 
 (purescript
   (function
-    name: (variable)
-    rhs: (exp_do
-      (stmt
+    (variable)
+    (exp_ado
+      (statement
         (let
-          (decls
+          (declarations
             (function
-              name: (variable)
-              rhs: (exp_name
+              (variable)
+              (exp_name
                 (variable))))))
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
-              pattern: (pat_apply
+              (pat_apply
                 (pat_name
                   (constructor))
                 (pat_name
                   (variable)))
-              rhs: (exp_name
+              (exp_name
                 (variable))))))
-      (stmt
-        (exp_let_in
-          (exp_let
-            (decls
-              (function
-                pattern: (pat_apply
-                  (pat_name
-                    (constructor))
-                  (pat_name
-                    (variable))
-                  (pat_name
-                    (variable)))
-                rhs: (exp_name
-                  (variable)))))
-          (exp_in
-            (exp_literal
-              (integer))))))))
+      (statement
+        (let
+          (declarations
+            (function
+              (pat_apply
+                (pat_name
+                  (constructor))
+                (pat_name
+                  (variable))
+                (pat_name
+                  (variable)))
+              (exp_name
+                (variable))))))
+      (exp_literal
+        (integer)))))
 
 ================================================================================
-Ado-notation, nested do-notation
+Ado-notation, nested ado-notation
 ================================================================================
 
 f = ado
@@ -277,16 +265,38 @@ f = ado
 
 (purescript
   (function
-    name: (variable)
-    rhs: (exp_do
-      (stmt
-        (exp_apply
-          (exp_name
-            (variable))
-          (exp_do
-            (stmt
-              (exp_apply
-                (exp_name
-                  (variable))
-                (exp_literal
-                  (integer))))))))))
+    (variable)
+    (exp_ado
+      (exp_ado
+        (exp_literal
+          (integer))))))
+
+================================================================================
+Ado-notation, single line
+================================================================================
+
+f = ado [] in []
+g = ado let a = [] in a
+
+--------------------------------------------------------------------------------
+
+(ERROR
+  (variable)
+  (statement
+    (exp_array))
+  (exp_apply
+    (exp_array)
+    (exp_name
+      (variable)))
+  (operator)
+  (statement
+    (let
+      (declarations
+        (function
+          (variable)
+          (exp_apply
+            (exp_array)
+            (exp_name
+              (variable))
+            (exp_name
+              (variable))))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -78,7 +78,7 @@ f a = 1
     rhs: (exp_literal
       (integer))
     (where)
-    (decls
+    (declarations
       (function
         name: (variable)
         rhs: (exp_literal
@@ -107,18 +107,16 @@ f a = let g b = 1 in g
       (pat_name
         (variable)))
     rhs: (exp_let_in
-      (exp_let
-        (decls
-          (function
-            name: (variable)
-            patterns: (patterns
-              (pat_name
-                (variable)))
-            rhs: (exp_literal
-              (integer)))))
-      (exp_in
-        (exp_name
-          (variable))))))
+      (declarations
+        (function
+          name: (variable)
+          patterns: (patterns
+            (pat_name
+              (variable)))
+          rhs: (exp_literal
+            (integer))))
+      (exp_name
+        (variable)))))
 
 ================================================================================
 Function as a let binder
@@ -137,9 +135,9 @@ f a = do
       (pat_name
         (variable)))
     rhs: (exp_do
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
               name: (variable)
               patterns: (patterns
@@ -147,7 +145,7 @@ f a = do
                   (variable)))
               rhs: (exp_literal
                 (integer))))))
-      (stmt
+      (statement
         (exp_name
           (variable))))))
 

--- a/test/corpus/rows-and-records.txt
+++ b/test/corpus/rows-and-records.txt
@@ -262,7 +262,7 @@ f = ok where ok { a: b, c: d, f } = ok
     rhs: (exp_name
       (variable))
     (where)
-    (decls
+    (declarations
       (function
         name: (variable)
         patterns: (patterns
@@ -328,30 +328,28 @@ f = let g { a: b, c: d, f } = ok in g
   (function
     name: (variable)
     rhs: (exp_let_in
-      (exp_let
-        (decls
-          (function
-            name: (variable)
-            patterns: (patterns
-              (pat_record
-                fields: (pat_fields
-                  (pat_field
-                    (field_name)
-                    (pat_name
-                      (variable)))
-                  (comma)
-                  (pat_field
-                    (field_name)
-                    (pat_name
-                      (variable)))
-                  (comma)
-                  (pat_field
-                    (field_name)))))
-            rhs: (exp_name
-              (variable)))))
-      (exp_in
-        (exp_name
-          (variable))))))
+      (declarations
+        (function
+          name: (variable)
+          patterns: (patterns
+            (pat_record
+              fields: (pat_fields
+                (pat_field
+                  (field_name)
+                  (pat_name
+                    (variable)))
+                (comma)
+                (pat_field
+                  (field_name)
+                  (pat_name
+                    (variable)))
+                (comma)
+                (pat_field
+                  (field_name)))))
+          rhs: (exp_name
+            (variable))))
+      (exp_name
+        (variable)))))
 
 ================================================================================
 record literal in a let binding pattern
@@ -367,9 +365,9 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (let
-          (decls
+          (declarations
             (function
               name: (variable)
               patterns: (patterns
@@ -389,7 +387,7 @@ f = do
                       (field_name)))))
               rhs: (exp_name
                 (variable))))))
-      (stmt
+      (statement
         (exp_name
           (variable))))))
 
@@ -407,7 +405,7 @@ f = do
   (function
     name: (variable)
     rhs: (exp_do
-      (stmt
+      (statement
         (bind_pattern
           (pat_record
             fields: (pat_fields
@@ -425,7 +423,7 @@ f = do
                 (field_name))))
           (exp_name
             (variable))))
-      (stmt
+      (statement
         (exp_name
           (variable))))))
 
@@ -828,4 +826,3 @@ a = C.d.e."e"."f".g
       (string)
       (string)
       (variable))))
-


### PR DESCRIPTION
Currently the `in` terminator incorrectly parses as a regular variable rather than a keyword.

A complication here is that do/ado blocks are allowed to use `let` binders, which in turn has ambiguous interpretation wrt `let in` expressions, so something like
```
ado
  let a = 1
  in a
```
becomes rather tricky. On top of that come the layout issues. The solution is to remove `let in` expressions from the list of options for a do/ado-block binder-indentation level statements. They aren't allowed in PS itself, unless parenthesized. But this is buried a bit deep inside a hierarchy of parsers so the code involves some duplication, basically writing out almost the same thing twice, for do/ado blocks and for normal notation. It still doesn't handle cases where `in` terminator is one the same line with a `let` binder, so it will require some more fiddling.