### PR TITLE
fix: scanner: make `state_new()` static

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -215,7 +215,7 @@ typedef struct {
 #endif
 } State;
 
-State state_new(TSLexer *l, const bool * restrict vs, indent_vec *is) {
+static State state_new(TSLexer *l, const bool * restrict vs, indent_vec *is) {
   return (State) {
     .lexer = l,
     .symbols = vs,


### PR DESCRIPTION
I suspect this is what's causing issues for multiple projects attempting to use this grammar:

- https://github.com/neurocyte/zat/issues/1

- https://github.com/zed-industries/zed/pull/7543#issuecomment-1934395267

Don't know why it wasn't static in the first place (in the original Haskell grammar), but I looked at what other grammars do and none export any functions other than those used by Tree-sitter.